### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = ""

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 _This is forked from https://sourceforge.net/projects/igcc/. I have done some refactoring and ported to Python 3.7, currently maintaining it._
 
+
+[![Run on Repl.it](https://repl.it/badge/github/kgashok/igcc)](https://repl.it/github/kgashok/igcc)
+
 Interactive GCC (igcc) is a read-eval-print loop (REPL) for C/C++ programmers.
 The `cstdio`, `iostream` and `string` headers are automatically included,
 and the `std namespace` is automatically in scope.


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@ashokb/igcc-1).